### PR TITLE
Allow selecting the rclone command

### DIFF
--- a/charts/rclone-copy/templates/_helpers.tpl
+++ b/charts/rclone-copy/templates/_helpers.tpl
@@ -27,3 +27,11 @@ Create chart name and version as used by the chart label.
 {{- define "rclone-copy.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "rclone-copy.getSourceOrUrl" -}}
+{{- if .Values.sync.url -}}
+{{ .Values.sync.url -}}
+{{- else -}}
+{{ .Values.sync.source.name }}:{{ .Values.sync.source.path -}}
+{{- end -}}
+{{- end -}}

--- a/charts/rclone-copy/templates/rclone-cron.yaml
+++ b/charts/rclone-copy/templates/rclone-cron.yaml
@@ -66,7 +66,7 @@ spec:
               # copy as workaround for rclone.conf read only (see https://github.com/rclone/rclone/issues/3655)
               - >-
                 cp /root/.config/rclone/rclone_ro.conf /root/.config/rclone/rclone.conf &&
-                rclone {{ .Values.command }} -v {{ .Values.arguments | join " " }} --include-from /root/include-pattern.conf "{{ .Values.sync.source.name }}:{{ .Values.sync.source.path }}" "{{ .Values.sync.dest.name }}:{{ .Values.sync.dest.path }}"
+                rclone {{ .Values.command }} -v {{ .Values.arguments | join " " }} --include-from /root/include-pattern.conf "{{ include "rclone-copy.getSourceOrUrl" . }}" "{{ .Values.sync.dest.name }}:{{ .Values.sync.dest.path }}"
 
             volumeMounts:
               - name: config

--- a/charts/rclone-copy/templates/rclone-cron.yaml
+++ b/charts/rclone-copy/templates/rclone-cron.yaml
@@ -58,7 +58,7 @@ spec:
           - name: rclone-container
             image: rclone/rclone:{{ .Values.imageRelease }}
             imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
-            
+
             command:
               - /bin/sh
             args:
@@ -66,8 +66,8 @@ spec:
               # copy as workaround for rclone.conf read only (see https://github.com/rclone/rclone/issues/3655)
               - >-
                 cp /root/.config/rclone/rclone_ro.conf /root/.config/rclone/rclone.conf &&
-                rclone copy -v {{ .Values.arguments | join " " }} --include-from /root/include-pattern.conf "{{ .Values.sync.source.name }}:{{ .Values.sync.source.path }}" "{{ .Values.sync.dest.name }}:{{ .Values.sync.dest.path }}"
-            
+                rclone {{ .Values.command }} -v {{ .Values.arguments | join " " }} --include-from /root/include-pattern.conf "{{ .Values.sync.source.name }}:{{ .Values.sync.source.path }}" "{{ .Values.sync.dest.name }}:{{ .Values.sync.dest.path }}"
+
             volumeMounts:
               - name: config
                 # This is the default path where the rclone implementation assumes the config is located
@@ -76,7 +76,7 @@ spec:
               - name: include-config
                 mountPath: "/root/include-pattern.conf"
                 subPath: "include-pattern.conf"
-            
+
             resources:
 {{ toYaml .Values.resources | indent 14 }}
 
@@ -97,7 +97,7 @@ spec:
                     key: "{{ $value.key }}"
             {{- end }}
             {{- end }}
-          
+
           restartPolicy: {{ .Values.restartPolicy }}
           volumes:
             - name: config
@@ -107,4 +107,3 @@ spec:
               configMap:
                 name: rclone-config-{{ .Release.Name }}
       backoffLimit: {{ .Values.backoffLimit }}
-

--- a/charts/rclone-copy/values.yaml
+++ b/charts/rclone-copy/values.yaml
@@ -14,6 +14,9 @@ sync:
     # This is the path to the source directory.
     path: /tmp/sync-dir
 
+  # Alternatively for the case of `rclone copyurl`, provide a URL instead of a source
+  url: https://example.com/myFileDownload
+
   dest:
     # This is the name for the destination remote from the rclone.conf file.
     # If the value specified here is not present in the config file, the job will fail.

--- a/charts/rclone-copy/values.yaml
+++ b/charts/rclone-copy/values.yaml
@@ -3,7 +3,7 @@ nameOverride: bakdata-rclone-copy
 # This is the cofiguration for the specific rclone-cronjob that you want to run.
 # `sync` contains the config for the source and destination of the rclone copy job.
 # It can be interpreted as:
-# rclone copy {source.name}:{source.path} {dest.name}:{dest.path}
+# rclone {command} {sync.source.name}:{sync.source.path} {sync.dest.name}:{sync.dest.path}
 sync:
   source:
     # This is the name for the source remote from the rclone.conf file.
@@ -22,6 +22,9 @@ sync:
 
     # This is the path to the target directory.
     path: my-s3-bucket
+
+# The rclone command to run. Default is "copy".
+command: "copy"
 
 # Additional arguments to pass to rclone.
 # The expected value is an array with comma seperated flag and value passed as a string.

--- a/charts/rclone-copy/values.yaml
+++ b/charts/rclone-copy/values.yaml
@@ -1,5 +1,8 @@
 nameOverride: bakdata-rclone-copy
 
+# The rclone command to run. Default is "copy".
+command: "copy"
+
 # This is the cofiguration for the specific rclone-cronjob that you want to run.
 # `sync` contains the config for the source and destination of the rclone copy job.
 # It can be interpreted as:
@@ -25,9 +28,6 @@ sync:
 
     # This is the path to the target directory.
     path: my-s3-bucket
-
-# The rclone command to run. Default is "copy".
-command: "copy"
 
 # Additional arguments to pass to rclone.
 # The expected value is an array with comma seperated flag and value passed as a string.

--- a/charts/rclone-copy/values.yaml
+++ b/charts/rclone-copy/values.yaml
@@ -15,7 +15,7 @@ sync:
     path: /tmp/sync-dir
 
   # Alternatively for the case of `rclone copyurl`, provide a URL instead of a source
-  url: https://example.com/myFileDownload
+  url: ""
 
   dest:
     # This is the name for the destination remote from the rclone.conf file.


### PR DESCRIPTION
So far, the chart is restricted to [rclone copy](https://rclone.org/commands/rclone_copy). This PR allows the command to be set (e.g. to invoke [rclone copyurl](https://rclone.org/commands/rclone_copyurl)). 

`copy` is retained as the default command to avoid introducing a breaking change.